### PR TITLE
Fix room_invitation_payload function issue

### DIFF
--- a/src/wechaty_puppet_service/puppet.py
+++ b/src/wechaty_puppet_service/puppet.py
@@ -675,7 +675,7 @@ class PuppetService(Puppet):
             id=room_invitation_id,
             payload=payload
         )
-        return RoomInvitationPayload(**response.to_dict())
+        return response
 
     async def room_invitation_accept(self, room_invitation_id: str) -> None:
         """


### PR DESCRIPTION
### Issue

I encountered issues when using the `room_invitation_payload` function. An unrelated variable name, `InviterId`, triggered an error. This pointed towards possible inconsistencies in how the function was handling its response compared to other functions in the system.

For more detailed background, please refer to the related issue: [Issue #354](https://github.com/wechaty/python-wechaty/issues/354).

### Solution

On examining other functions, specifically the ones related to `friendship`, I observed that they directly returned the response. Believing this to be a more consistent and streamlined way of handling the functionality, I applied the same pattern to the `room_invitation_payload` function.

### Changes
- Adjusted the `room_invitation_payload` function to directly return the response, aligning its behavior with that of other functions like `friendship`.
- Resolved the `InviterId` variable error.

I'd appreciate any feedback on these changes and any necessary adjustments you'd recommend.

Thank you!
